### PR TITLE
Fix deprecated method - resolves #3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,7 @@ dependencies {
     // compileOnly fg.deobf("mezz.jei:jei-${mc_version}-forge-api:${jei_version}")
     // runtimeOnly fg.deobf("mezz.jei:jei-${mc_version}-forge:${jei_version}")
 
-    implementation fg.deobf("curse.maven:cold-sweat-506194:5874633")
+    implementation fg.deobf("curse.maven:cold-sweat-506194:7370183")
     implementation fg.deobf("curse.maven:jade-324717:5672013")
 
 

--- a/src/main/java/net/kermir/cslcrops/Cslcrops.java
+++ b/src/main/java/net/kermir/cslcrops/Cslcrops.java
@@ -3,6 +3,7 @@ package net.kermir.cslcrops;
 import com.mojang.datafixers.util.Either;
 import com.mojang.logging.LogUtils;
 import com.momosoftworks.coldsweat.api.util.Temperature;
+import com.momosoftworks.coldsweat.util.world.WorldHelper;
 import net.kermir.cslcrops.data.CropData;
 import net.kermir.cslcrops.data.CropsNSeedsData;
 import net.kermir.cslcrops.network.PacketChannel;
@@ -111,7 +112,7 @@ public class Cslcrops {
     @SuppressWarnings("DataFlowIssue")
     private void onTreeAndPlant(Level level, String blockResLoc, BlockPos blockPos, Event event) {
         if (CropsNSeedsData.CROPS_MAP.containsKey(blockResLoc)) {
-            double temp = Temperature.getTemperatureAt(blockPos, level);
+            double temp = WorldHelper.getTemperatureAt(level, blockPos);
             CropData data = CropsNSeedsData.CROPS_MAP.get(blockResLoc);
 
             if (data.isColder(temp, Temperature.Units.MC)) event.setResult(Event.Result.DENY);

--- a/src/main/java/net/kermir/cslcrops/network/ReqBlockTempData.java
+++ b/src/main/java/net/kermir/cslcrops/network/ReqBlockTempData.java
@@ -2,6 +2,7 @@ package net.kermir.cslcrops.network;
 
 import com.momosoftworks.coldsweat.api.util.Temperature;
 import com.momosoftworks.coldsweat.config.spec.ClientSettingsConfig;
+import com.momosoftworks.coldsweat.util.world.WorldHelper;
 import net.kermir.cslcrops.Cslcrops;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.FriendlyByteBuf;
@@ -33,7 +34,7 @@ public class ReqBlockTempData {
         if (context.getSender() == null) return true;
 
         context.enqueueWork(() -> {
-            double temperature = Temperature.getTemperatureAt(this.cropPos, context.getSender().level());
+            double temperature = WorldHelper.getTemperatureAt(context.getSender().level(), this.cropPos);
             PacketChannel.sendToClient(new RecBlockTempData(cropPos, temperature), context.getSender());
         });
 


### PR DESCRIPTION
Cold Sweat's API deprecated Temperature.getTemperatureAt(), an identical non-deprecated method exists at WorldHelper.getTemperatureAt()